### PR TITLE
[PR-27228] Upgrade Demo App target to Android 17 (API 37)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_ACCESS_TOKEN
-        image: cimg/android:2024.01.1
+        image: cimg/android:2026.07.1
         environment:
           JVM_OPTS: -Xmx3200m
 
@@ -19,7 +19,7 @@ jobs:
           key: v2-dependencies-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
       - run:
           name: Download dependencies
-          command: ./gradlew androidDependencies
+          command: ./gradlew :sdk:dependencies :app:dependencies
       - save_cache:
           paths:
             - ~/.gradle

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -80,16 +80,16 @@ All version and build configuration lives in `gradle.properties`:
 
 | Property | Description | Example |
 |---|---|---|
-| `android_build_tools` | Build tools version (shared) | `36.0.0` |
+| `android_build_tools` | Build tools version (shared) | `37.0.0` |
 | `sdk_compile_sdk` | SDK compile SDK version | `35` |
-| `sdk_target_sdk` | SDK target SDK version | `35` |
+| `sdk_target_sdk` | SDK target SDK version (instrumented tests only as of AGP 9) | `35` |
 | `sdk_min_sdk` | SDK module minimum SDK | `16` |
 | `sdk_version_code` | SDK version code (integer) | `43` |
 | `sdk_version_name` | SDK version name (semver) | `0.5.14` |
-| `app_compile_sdk` | App compile SDK version | `35` |
-| `app_target_sdk` | App target SDK version | `35` |
+| `app_compile_sdk` | App compile SDK version | `37` |
+| `app_target_sdk` | App target SDK version | `37` |
 | `app_min_sdk` | App module minimum SDK | `21` |
-| `app_version_code` | App module version code | `3` |
-| `app_version_name` | App module version name | `1.0.0` |
+| `app_version_code` | App module version code | `4` |
+| `app_version_name` | App module version name | `1.0.1` |
 
 Both `sdk/build.gradle` and `app/build.gradle` read from these properties. Do not hardcode build config values in the module build files.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,35 +4,35 @@ def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(rootProject.file("keystore.properties")))
 
 android {
-    namespace 'com.talkable.appdemo'
+    namespace = 'com.talkable.appdemo'
     signingConfigs {
         config {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            keyAlias = keystoreProperties['keyAlias']
+            keyPassword = keystoreProperties['keyPassword']
+            storeFile = file(keystoreProperties['storeFile'])
+            storePassword = keystoreProperties['storePassword']
         }
     }
-    compileSdkVersion Integer.parseInt(project.app_compile_sdk)
+    compileSdk = Integer.parseInt(project.app_compile_sdk)
     defaultConfig {
-        applicationId "com.talkable.appdemo2"
-        minSdkVersion Integer.parseInt(project.app_min_sdk)
-        targetSdkVersion Integer.parseInt(project.app_target_sdk)
-        versionCode Integer.parseInt(project.app_version_code)
-        versionName project.app_version_name
+        applicationId = "com.talkable.appdemo2"
+        minSdk = Integer.parseInt(project.app_min_sdk)
+        targetSdk = Integer.parseInt(project.app_target_sdk)
+        versionCode = Integer.parseInt(project.app_version_code)
+        versionName = project.app_version_name
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.config
+            signingConfig = signingConfigs.config
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
-    buildToolsVersion project.android_build_tools
+    buildToolsVersion = project.android_build_tools
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
     buildTypes {
         release {
             minifyEnabled = false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig = signingConfigs.config
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.2'
-        classpath 'com.github.bjoernq:unmockplugin:0.7.8'
+        classpath 'com.android.tools.build:gradle:9.3.0'
+        classpath 'com.github.bjoernq:unmockplugin:0.11.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -17,10 +17,10 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven { url 'https://jitpack.io' }
+        maven { url = 'https://jitpack.io' }
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,13 +16,11 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.defaults.buildfeatures.buildconfig=true
-android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
 
-android_build_tools=36.0.0
+android_build_tools=37.0.0
 
 sdk_compile_sdk=35
 sdk_target_sdk=35
@@ -30,8 +28,8 @@ sdk_min_sdk=16
 sdk_version_code=43
 sdk_version_name=0.5.14
 
-app_compile_sdk=35
-app_target_sdk=35
+app_compile_sdk=37
+app_target_sdk=37
 app_min_sdk=21
-app_version_code=3
-app_version_name=1.0.0
+app_version_code=4
+app_version_name=1.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -5,32 +5,40 @@ apply plugin: 'maven-publish'
 group='com.github.talkable'
 
 android {
-    namespace 'com.talkable.sdk'
-    compileSdkVersion Integer.parseInt(project.sdk_compile_sdk)
+    namespace = 'com.talkable.sdk'
+    compileSdk = Integer.parseInt(project.sdk_compile_sdk)
 
     defaultConfig {
-        minSdkVersion Integer.parseInt(project.sdk_min_sdk)
-        targetSdkVersion Integer.parseInt(project.sdk_target_sdk)
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        minSdk = Integer.parseInt(project.sdk_min_sdk)
+        testInstrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
 
         // Required for sdk version retrieval to work as of Android Studio 4.1.0: https://issuetracker.google.com/issues/158695880
         buildConfigField 'int', 'VERSION_CODE', "${project.sdk_version_code}"
         buildConfigField 'String', 'VERSION_NAME', "\"${project.sdk_version_name}\""
     }
+    buildFeatures {
+        buildConfig = true
+    }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     testOptions {
+        // targetSdk on library modules only applies to instrumented tests as of AGP 9
+        targetSdk = Integer.parseInt(project.sdk_target_sdk)
         unitTests.returnDefaultValues = true
     }
     lint {
-        abortOnError false
+        abortOnError = false
     }
-    buildToolsVersion project.android_build_tools
+    buildToolsVersion = project.android_build_tools
 
     publishing {
         singleVariant('release') {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ android {
     buildTypes {
         release {
             minifyEnabled = false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {
@@ -34,6 +34,15 @@ android {
         // targetSdk on library modules only applies to instrumented tests as of AGP 9
         targetSdk = Integer.parseInt(project.sdk_target_sdk)
         unitTests.returnDefaultValues = true
+        unitTests.all {
+            // PowerMock 1.6.6/Objenesis need reflective access that JDK 17+ encapsulates
+            jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
+                    '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
+                    '--add-opens=java.base/java.util=ALL-UNNAMED',
+                    '--add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED',
+                    // OkHttp 3.2.0 reflects into the JDK's SSL internals on the test JVM
+                    '--add-opens=java.base/sun.security.ssl=ALL-UNNAMED'
+        }
     }
     lint {
         abortOnError = false
@@ -68,14 +77,12 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
 
-    testImplementation 'org.mockito:mockito-core:1.10.19'
-    testImplementation('org.powermock:powermock-api-mockito:1.6.6') {
+    testImplementation 'org.mockito:mockito-core:2.28.2'
+    testImplementation('org.powermock:powermock-api-mockito2:2.0.9') {
         exclude module: 'hamcrest-core'
-        exclude module: 'objenesis'
     }
-    testImplementation('org.powermock:powermock-module-junit4:1.6.6') {
+    testImplementation('org.powermock:powermock-module-junit4:2.0.9') {
         exclude module: 'hamcrest-core'
-        exclude module: 'objenesis'
     }
 
     androidTestImplementation 'androidx.annotation:annotation:1.8.2'


### PR DESCRIPTION
## Why

Google Play requires apps to target **API 36+ by Aug 31, 2026** ([target API level policy](https://support.google.com/googleplay/android-developer/answer/11926878)). This PR targets **API 37** (Android 17, the latest stable release) instead of the minimum 36, so the app also clears the next annual deadline without another bump.

## What changed

**The actual requirement (app module only):**
- `app_target_sdk` / `app_compile_sdk`: 35 → 37; `app_version_code` 3 → 4, versionName 1.0.1

**SDK library — public contract unchanged:** compileSdk/targetSdk 35, minSdk 16, version 0.5.14. The Play policy applies only to the uploaded app binary, and the SDK keeps its documented Android 4.1+ support, so no SDK release is part of this PR.

**Toolchain cascade forced by compileSdk 37** (per the [AGP compatibility table](https://developer.android.com/build/releases/about-agp) it needs AGP ≥ 9.1.1):
- AGP 8.5.2 → 9.3.0, Gradle 8.7 → 9.5.0, build-tools 37.0.0, unmock plugin 0.7.8 → 0.11.0
- Groovy DSL migration in both modules: AGP 9 removed `compileSdkVersion`/`minSdkVersion`/`targetSdkVersion`; `=` assignments replace the space syntax Gradle 10 removes; library `targetSdk` moved to `testOptions` (AGP 9 requirement)
- `buildFeatures { buildConfig = true }` in `sdk` replaces the removed `android.defaults.buildfeatures.buildconfig` flag; dropped `android.enableJetifier` (all deps are AndroidX)
- CircleCI image → `cimg/android:2026.07.1` (JDK 21, SDK 37 preinstalled); removed-in-AGP-9 `androidDependencies` task replaced with `:sdk:dependencies :app:dependencies`
- `proguard-android-optimize.txt` replaces `proguard-android.txt` in both modules — AGP 9 rejects the old default file (inert while `minifyEnabled = false`)
- Test-only: PowerMock 1.6.6/Mockito 1.10.19 → PowerMock 2.0.9/Mockito 2.28.2 plus `--add-opens` test JVM args — the old stack cannot run on JDK 17+ (broken since CI dropped the Java 8 pin); full `:sdk:test` passes on JDK 21 with this toolchain
- New `jitpack.yml` pinning JDK 17 — JitPack's default JDK 8 can't run Gradle 9, which would have broken the next tagged release build

## Draft until

- CI passes on this PR (build + `:sdk:test` verified locally on JDK 21 / Gradle 9.5 / AGP 9.3 / SDK 37)
- Android Studio sync (requires Studio Panda 3+ for API 37)
- Demo app pass on Android 17 — note targeting 36+ makes edge-to-edge mandatory, so check for UI drawing under system bars
